### PR TITLE
Fix novacodecoffee.com link

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-9">
         <h2>DC Code &amp; Coffee</h2>
-        <p>This group meets every other week on Sundays at either <a href="https://www.arcadiapower.com/" class="slightly-bold">Arcadia Power</a> <a href="https://www.google.com/maps?q=1121%2014th%20St%20NW%20Washington,%20DC%2020005">(map)</a> headquarters in downtown DC, or <a href="https://www.usnews.com/" class="slightly-bold">U.S. News &amp; World Report</a> <a href="1050 Thomas Jefferson St NW, Washington, DC 20007">(map)</a> headquarters in Georgetown. Developers of all skill levels come together to work on and discuss projects with each other. You may also be interested in our sister groups <a href="http://www.novacodecoffee.com" class="slightly-bold">NoVa Code &amp; Coffee</a> and <a href="http://www.alxcodecoffee.com" class="slightly-bold">Alexandria Code &amp; Coffee</a>.</p>
+        <p>This group meets every other week on Sundays at either <a href="https://www.arcadiapower.com/" class="slightly-bold">Arcadia Power</a> <a href="https://www.google.com/maps?q=1121%2014th%20St%20NW%20Washington,%20DC%2020005">(map)</a> headquarters in downtown DC, or <a href="https://www.usnews.com/" class="slightly-bold">U.S. News &amp; World Report</a> <a href="1050 Thomas Jefferson St NW, Washington, DC 20007">(map)</a> headquarters in Georgetown. Developers of all skill levels come together to work on and discuss projects with each other. You may also be interested in our sister groups <a href="http://novacodecoffee.com" class="slightly-bold">NoVa Code &amp; Coffee</a> and <a href="http://www.alxcodecoffee.com" class="slightly-bold">Alexandria Code &amp; Coffee</a>.</p>
       </div>
       <div class="col-md-3 tc">
         <h3>Chat</h3>


### PR DESCRIPTION
Fixes a broken link to http://www.novacodecoffee.com/ which should be http://novacodecoffee.com/

👕 👕 👕 👕 ✅ 