### PR TITLE
Add code of conduct.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Code of Conduct
+
+DC Code and Coffee is dedicated to providing a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of group participants in any form. Sexual language and imagery is not appropriate for any event or communication channel. Group participants violating these rules may be sanctioned or expelled from the event at the discretion of the organizers.
+
+Harassment includes, but is not limited to:
+
+- Verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or level of experience
+- Sexual images in public spaces
+- Deliberate intimidation, stalking, or following
+- Harassing photography or recording
+- Sustained disruption of discussion or other events
+- Inappropriate physical contact
+- Unwelcome sexual attention
+- Advocating for, or encouraging, any of the above behaviour
+
+## Enforcement
+
+Participants asked to stop any harassing behavior are expected to comply immediately. If a participant engages in harassing behaviour, event organisers retain the right to take any actions to keep the event a welcoming environment for all participants. This includes warning the offender or expulsion from the event.
+
+We expect participants to follow these rules at all event venues and event-related social activities.
+
+## Reporting
+
+If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible. Group organizers can be [identified on Meetup][1]. Harassment and other code of conduct violations reduce the value of our event for everyone. We want you to be happy at our event. People like you make our event a better place.
+
+You can make a report either personally or anonymously.
+
+### Anonymous Report
+
+You can make an anonymous report. We can't follow up an anonymous report with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.
+
+### Personal Report
+
+You can make a personal report by:
+
+- Contacting a [group organizer on Meetup][1].
+- Emailing organizer Andrew Dunkman at [adunkman@gmail.com](mailto:adunkman@gmail.com?subject=URGENT:%20DC%20Code%20and%20Coffee%20Code%20of%20Conduct%20violation).
+- Emailing organizer Jax Garry at [jacqueline.m.garry@gmail.com](mailto:jacqueline.m.garry@gmail.com?subject=URGENT:%20DC%20Code%20and%20Coffee%20Code%20of%20Conduct%20violation).
+
+When taking a personal report, our organizers may involve other organizers to ensure your report is managed properly. This can be upsetting, but we'll handle it as respectfully as possible, and you can include someone to support you. You won't be asked to confront anyone and we won't tell anyone who you are.
+
+Our team will be happy to help you contact law enforcement, provide escorts, or otherwise assist you to feel safe for the duration of the event. We value your attendance.
+
+- [Organizers group on Meetup][1].
+- DC Police can be reached at [911](tel:911) (emergency) or [311](tel:311) (non-emergency).
+- The DC Rape Crisis Center can be reached at [202-333-7273](tel:2023337273).
+
+## Attribution
+
+This Code of Conduct is adapted from [the Geek Feminism conference anti-harassment policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+[1]: https://www.meetup.com/dc-code-coffee/members/?op=leaders

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,6 +5,7 @@
     <div class="tc">
       <span>DC Code &amp; Coffee</span>
       <span>&copy; {{ site.time | date: '%Y' }} contributors</span>
+      <span><a href="https://github.com/dccodecoffee/dccodecoffee.github.io/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a></span>
     </div>
   </footer>
 </div>


### PR DESCRIPTION
This adds the code of conduct we’ve agreed upon as organizers to this repository, and links to the repository copy in the footer of the site.

Notably **missing is the anonymous report form** — I’ll be taking a swing at that shortly, but didn’t want to hold this up! 